### PR TITLE
add bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,22 @@
+{
+  "name": "geomicons-open",
+  "version": "0.0.6",
+  "description": "Open Source Icons for the Web",
+  "main": [
+    "dist/geomicons.js",
+    "dist/geomicons.min.js",
+  ],
+  "ignore": [
+    "docs",
+    "gulp",
+    "icons",
+    "src",
+    ".gitignore",
+    "CNAME",
+    "geomicons-defs.svg",
+    "geomicons.svg",
+    "gulpfile.js",
+    "index.html",
+    "pckage.json"
+  ]
+}


### PR DESCRIPTION
Add bower.json to the project. The goal is to make the icons available on [Bower](http://bower.io).

After this PR, registration on Bower can be made with:

    bower register geomicons-open git://github.com/jxnblk/geomicons-open.git


