### PR TITLE
get icon name via getAttribute (el.dataset undefined for SVG els)

### DIFF
--- a/docs/template.html
+++ b/docs/template.html
@@ -117,7 +117,7 @@
       document.body.classList.add('has-zeroclipboard');
       zero.on('copy', function(e) {
         var el = e.target.querySelector('.js-geomicon');
-        iconName = el.dataset.icon;
+        iconName = el.getAttribute('data-icon');
         var string = e.target.innerHTML;
         zero.setText(string);
       });

--- a/index.html
+++ b/index.html
@@ -337,7 +337,7 @@
       document.body.classList.add('has-zeroclipboard');
       zero.on('copy', function(e) {
         var el = e.target.querySelector('.js-geomicon');
-        iconName = el.dataset.icon;
+        iconName = el.getAttribute('data-icon');
         var string = e.target.innerHTML;
         zero.setText(string);
       });


### PR DESCRIPTION
In the copy to clipboard 'copy' event handler, the `iconName` variable was being set to `el.dataset.icon` where `el` is the SVG icon (https://github.com/jxnblk/geomicons-open/blob/master/index.html#L340). Strangely, HTMLElement.dataset doesn't seem to be supported for SVG elements (see https://bugzilla.mozilla.org/show_bug.cgi?id=921834, https://lists.w3.org/Archives/Public/public-whatwg-archive/2013Feb/0019.html). For some reason, this was failing silently: `el.dataset` became undefined and `el.dataset.icon` was failing but not throwing an error to the console. Everything after that, namely setting the text content to be copied to clipboard, wasn't evaluated. This resulted in nothing being copied to clipboard :(

Switching to `getAttribute` fixes this and everyone can once again copy these awesome icons! Thanks for this fantastic open-source resource! 
